### PR TITLE
Update pbreq.js

### DIFF
--- a/lib/pbreq.js
+++ b/lib/pbreq.js
@@ -8,8 +8,8 @@ module.exports= {
 	headers:{}	
 	},
 	
-	//endpoint:	"http://private-anon-041470838-profitbricksrestapi.apiary-mock.com",
-	endpoint: "https://spc.profitbricks.com/rest",
+	//Unsetting endpoint here, it needs to be defined by the calling app, or in a config file
+	endpoint: false,
 	
 	fullheader: function(){
 		pbreq.options.headers['Content-Type'] = 'application/vnd.profitbricks.resource+json'
@@ -57,7 +57,10 @@ module.exports= {
 	
 
 	mk_url: function(aray,callback){
-		
+		if (!pbreq.endpoint){
+			console.err('Please set libprofitbricks.endpoint to the rest server address')
+			return -1
+		}
 		aray.unshift(pbreq.endpoint)
     		pbreq.options.url=aray.join("/")+'?depth='+pbreq.depth
 		return pbreq.options.url


### PR DESCRIPTION
un-setting endpoint value, the application or end user can set it this way:
var libpb=require('libprofitbricks')
libpb.endpoint='https://spc.profitbricks.com/rest'